### PR TITLE
Fix set data box panic

### DIFF
--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -278,7 +278,7 @@ where
             }
             _ => {
                 log::error!("Embedder::embed : embedding optimization failed");
-                Err(1)
+                Err(anyhow!("Embedding optimization failed"))
             }
         }
     } // end of h_embed


### PR DESCRIPTION
Updated `set_data_box` to optionally return an `Err` instead of panicking. 
Propogated the error through related functions